### PR TITLE
Show the largest files for each file extension

### DIFF
--- a/duplicateFinder
+++ b/duplicateFinder
@@ -33,6 +33,24 @@ function extensions() {
   echo
 }
 
+function extensionsAndSizes() {
+  DIR="$1"
+  if [[ "${DIR}" == "" ]] ; then
+    echo "ERROR: extensions() requires a parameter."
+    exit 1
+  fi
+  echo -e "${GREEN}File extensions in ${DIR} ... ${NOCOLOR}"
+  echo
+  for type in $( find ${DIR} -type f | sed "s/^.*[.]//1" | sort | uniq -c | sort -n | awk '{ print $1 ":" $2 }' ) ; do
+    EXT=${type/*:/}
+    COUNT=${type/:*/}
+  echo "=== .${EXT} === total files: ${COUNT} === largest files (K) ===v"
+    du -ak ${DIR} | egrep "[.]${EXT}$" | sort -n | tail -6
+    echo
+  done
+  echo
+}
+
 [ -d ${REFDIR} ] || usage "ERROR: The reference dir is not available: ${REFDIR}"
 [ -d ${DIRTOSCAN} ] || usage "ERROR: The scan dir is not available: ${DIRTOSCAN}"
 
@@ -49,8 +67,8 @@ for s in $( awk '{ print $1 }' /var/tmp/md5Sums.txt | sort | uniq -c | egrep -v 
   echo
 done
 
-extensions "${REFDIR}"
-extensions "${DIRTOSCAN}"
+extensionsAndSizes "${REFDIR}"
+extensionsAndSizes "${DIRTOSCAN}"
 
 echo -e "${GREEN}Checking for duplicates in ${DIRTOSCAN} ... ${NOCOLOR}"
 echo


### PR DESCRIPTION
The file-by-file diff of $DIRTOSCAN is very slow. If we can move the
largest files out of it sooner then we can make the scan much faster.

If we can move all of the files for a single extension out then we can stop
looking at that extension and, thus, also stop scanning $REFDIR.