### PR TITLE
Exclude ~/Library files that we do not care about

### DIFF
--- a/backup.ccasey
+++ b/backup.ccasey
@@ -47,6 +47,8 @@ function AssertMounted() {
   fi
 }
 
+ROOT=$( dirname $0 )
+
 drive1=/Volumes/FileStore1
 echo ""
 drive2=/Volumes/FileStore2
@@ -78,7 +80,7 @@ echo ""
 src=/Users/ccaseysf
 dest=${drive1?}/ccaseysf
 mkdir -p ${dest?}
-rsync -a --delete --itemize-changes ${src?}/ ${dest?}
+rsync -a --delete --itemize-changes --exclude-from=${ROOT}/backup.exclude ${src?}/ ${dest?}
 
 for dir in ccaseysf FilesToKeep ; do
   src="${drive1?}/${dir?}"

--- a/backup.exclude
+++ b/backup.exclude
@@ -1,0 +1,6 @@
+.bash_sessions/
+Library/Application?Support/Active?Trader?Pro/
+Library/Application?Support/Google/Chrome/
+Library/Containers/com.apple.siri.media-indexer/
+Library/Caches
+Library/Logs


### PR DESCRIPTION
There are many files in ~/Library that we do not need to back up, like
the Chrome cache and anything about Blizzard. Exclude these.